### PR TITLE
Remove quiz progress info from top of quiz lessons

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
@@ -207,7 +207,9 @@ class FundaWande_Quiz {
         if(is_array($user_lesson_status ) && 1 == count($user_lesson_status )) {
             $user_lesson_status  = array_shift($user_lesson_status );
         }
-        $quiz_attempts = get_comment_meta($user_lesson_status->comment_ID, 'quiz_attempts', true);
+
+        //If no comment is found, return an empty string. If it is found, get the 'quiz-attempts' comment meta
+        $quiz_attempts = is_object($user_lesson_status) ? get_comment_meta($user_lesson_status->comment_ID, 'quiz_attempts', true) : '';
         
         return $quiz_attempts;
 

--- a/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
@@ -207,9 +207,7 @@ class FundaWande_Quiz {
         if(is_array($user_lesson_status ) && 1 == count($user_lesson_status )) {
             $user_lesson_status  = array_shift($user_lesson_status );
         }
-
-        //If no comment is found, return an empty string. If it is found, get the 'quiz-attempts' comment meta
-        $quiz_attempts = is_object($user_lesson_status) ? get_comment_meta($user_lesson_status->comment_ID, 'quiz_attempts', true) : '';
+        $quiz_attempts = get_comment_meta($user_lesson_status->comment_ID, 'quiz_attempts', true);
         
         return $quiz_attempts;
 

--- a/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-quiz.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-quiz.twig
@@ -38,4 +38,35 @@
     jQuery(document).ready( function($) {
         $('#{{ modal_id }}').modal('show');
     });
+
+
+    //Scroll down to quiz questions when the quiz modal is visible
+    function animate(elem, style, unit, from, to, time, prop) {
+        if (!elem) {
+            return;
+        }
+        var start = new Date().getTime(),
+            timer = setInterval(function() {
+            var step = Math.min(1, (new Date().getTime() - start) / time);
+            if (prop) {
+                elem[style] = from + step * (to - from) + unit;
+            } else {
+                elem.style[style] = from + step * (to - from) + unit;
+            }
+            if (step === 1) {
+                clearInterval(timer);
+            }
+            }, 25);
+        if (prop) {
+            elem[style] = from + unit;
+        } else {
+            elem.style[style] = from + unit;
+        }
+    }
+
+    window.onload = function () {
+        var target = document.getElementById("quiz-questions");
+        animate(document.scrollingElement || document.documentElement, "scrollTop", "", 0, target.offsetTop -350, 1000, true);
+    };
+
 </script>

--- a/wp-content/themes/fundawande/templates/lms/embeds/quiz-outcome-message.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/quiz-outcome-message.twig
@@ -29,33 +29,3 @@
     </div>
     <hr>
 </div>
-
-<script>
-    function animate(elem, style, unit, from, to, time, prop) {
-        if (!elem) {
-            return;
-        }
-        var start = new Date().getTime(),
-            timer = setInterval(function() {
-            var step = Math.min(1, (new Date().getTime() - start) / time);
-            if (prop) {
-                elem[style] = from + step * (to - from) + unit;
-            } else {
-                elem.style[style] = from + step * (to - from) + unit;
-            }
-            if (step === 1) {
-                clearInterval(timer);
-            }
-            }, 25);
-        if (prop) {
-            elem[style] = from + unit;
-        } else {
-            elem.style[style] = from + unit;
-        }
-    }
-
-    window.onload = function () {
-        var target = document.getElementById("quiz-questions");
-        animate(document.scrollingElement || document.documentElement, "scrollTop", "", 0, target.offsetTop -350, 1000, true);
-    };
-</script>

--- a/wp-content/themes/fundawande/templates/lms/single-quiz.twig
+++ b/wp-content/themes/fundawande/templates/lms/single-quiz.twig
@@ -29,10 +29,11 @@
         {# Include lesson header component #}
         {% include '/lms/embeds/lesson-header.twig' %}
 
+        {# TODO: Remove the quiz outcome message template once the FW team have confirmed they no longer want it #}
         {# If quiz outcome is set then show message and modal #}
-        {%  if (quiz_retry or lesson_complete or quiz_resubmit)  %}
+        {# {%  if (quiz_retry or lesson_complete or quiz_resubmit)  %}
             {% include "/lms/embeds/quiz-outcome-message.twig" %}
-        {% endif %}
+        {% endif %} #}
         {%  if (quiz_retry or lesson_complete) and show_notifications %}
             {% include '/lms/embeds/modals/modal-quiz.twig' %}
         {% endif %}


### PR DESCRIPTION
Closes #25 

The FW content team has decided to remove the progress information that pops up at the top of a lesson that has a completed quiz.

![image](https://user-images.githubusercontent.com/15672948/53074458-7f5cdb80-34f3-11e9-9f7d-ed2444382ef3.png)

This PR removes the information by commenting out the call to pull in the template. If the FW team are happy with the fix, we can remove the quiz outcome message template permanently

