### PR TITLE
Add spacer content type

### DIFF
--- a/wp-content/themes/fundawande/templates/lms/content-types/spacer.twig
+++ b/wp-content/themes/fundawande/templates/lms/content-types/spacer.twig
@@ -1,0 +1,2 @@
+<!-- Content Type: Spacer -->
+<div class = "col-12" style="height:{{content.spacer}}px;"></div>

--- a/wp-content/themes/fundawande/templates/lms/embeds/lesson-content.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/lesson-content.twig
@@ -115,11 +115,14 @@
                 {% elseif content.acf_fc_layout == 'carousel_pulled_right_with_text' %}
                     {% include '/lms/content-types/carousel/carousel-pulled-right-with-text.twig' %}
 
-                    {# Other Content Types #}
+                {# Other Content Types #}
 
                     {# Copy text #}
                 {% elseif content.acf_fc_layout == 'copy_text' %}
                     {% include '/lms/content-types/copy-text.twig' %}
+                    {# Spacer #}
+                {% elseif content.acf_fc_layout == 'spacer' %}
+                    {% include '/lms/content-types/spacer.twig' %}
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
This PR adds a new content type - the 'spacer'. This simple widget adds space between content types on lessons. It allows you to set the height of the space - between 0 and 100. 

![spacer](https://user-images.githubusercontent.com/15672948/53805444-d54d6c80-3f52-11e9-8800-c148510ec4dd.png)

This makes a significant difference on lessons with lots of content:


**Layout without spacers**

![busy_content_no_spaces](https://user-images.githubusercontent.com/15672948/53805491-f1510e00-3f52-11e9-8d02-946cbb1fae8f.png)


**Layout with spacers**

![busy_content_after_space](https://user-images.githubusercontent.com/15672948/53805497-f4e49500-3f52-11e9-8fbe-a26437cdadad.png)
