### PR TITLE
Comment out automatic instructions on dnd quizzes

### DIFF
--- a/wp-content/themes/fundawande/sensei/single-quiz/question_type-drag-and-drop-non-sequential.php
+++ b/wp-content/themes/fundawande/sensei/single-quiz/question_type-drag-and-drop-non-sequential.php
@@ -36,14 +36,14 @@ $uniqueId = FundaWande()->question->getUniqueId();
     <input type="hidden" name="sensei_question[<?= $question_data['ID'] ?>]">
 
     <div class="container-fluid">
-        <div>
+        <!-- <div>
             <p class="_text-desktop">
                 Match the following pages with the correct option given below:
             </p>
             <p class="_text-mobile">
                 View the following images and match them below (click image to enlarge)
             </p>
-        </div>
+        </div> -->
 
         <div class="row _option-images">
             <?php

--- a/wp-content/themes/fundawande/sensei/single-quiz/question_type-drag-and-drop-sequential.php
+++ b/wp-content/themes/fundawande/sensei/single-quiz/question_type-drag-and-drop-sequential.php
@@ -36,14 +36,14 @@ $uniqueId = FundaWande()->question->getUniqueId();
     <input type="hidden" name="sensei_question[<?= $question_data['ID'] ?>]">
 
     <div class="container-fluid">
-        <div>
+        <!-- <div>
             <p class="_text-desktop">
                 Arrange the following in the correct order by dragging them into the correct order:
             </p>
             <p class="_text-mobile">
                 Chose the most appropriate order of the following images (click to enlarge)
             </p>
-        </div>
+        </div> -->
 
         <div class="row _option-images">
             <?php


### PR DESCRIPTION
Closes #58 

Quizzes have duplicate instructions currently, as the Funda Wande team add personalised instructions for each quiz they add and the app already has a basic instruction available. 

![duplicate_instructions](https://user-images.githubusercontent.com/15672948/54181278-b1d07780-44a6-11e9-9ceb-8f06713cb3a9.png)

This PR simply comments out the automatic instructions. 

There are still instructions shown to users on mobile instructions below the images. 