### PR TITLE
Bug squashed: Sensei bug causing ordering issues when creating and updating lessons

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-lessons.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-lessons.php
@@ -159,7 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
      *
      */
     public function handle_save_post_lesson( $post_ID ) {
-       
+
 		if( !in_array( get_post_type( $post_ID ), array('lesson' ) ) ){
 			return;
 		}

--- a/wp-content/plugins/sensei/includes/class-sensei-core-lesson-modules.php
+++ b/wp-content/plugins/sensei/includes/class-sensei-core-lesson-modules.php
@@ -54,6 +54,7 @@ class Sensei_Core_Lesson_Modules {
 		// module is selected, or if the selected module does not exist in the
 		// given course.
 		if ( ! $module_id || empty( $module_id ) || ! $module_exists_in_course ) {
+
 			wp_delete_object_term_relationships( $this->lesson_id, $this->modules_taxonomy() );
 			return;
 		}
@@ -63,8 +64,15 @@ class Sensei_Core_Lesson_Modules {
 
 		// Set default order for lesson inside module
 		$order_module_key = '_order_module_' . $module_id;
-		if ( ! get_post_meta( $this->lesson_id, $order_module_key, true ) ) {
-			update_post_meta( $this->lesson_id, $order_module_key, 0 );
+		// Get the current position of the lesson in module
+		$position = get_post_meta( $this->lesson_id, $order_module_key, true );
+		// Get the post type to prevent the ordering of quizzes which messes up the ordering of lesosns
+		$post_type = get_post_type($this->lesson_id);
+		
+		// If the position is not set and the post type is a lesson then go ahead with the default ordering
+		if ( ! $position && $post_type === 'lesson') {
+			// Set the defualt ordering to 99 which will always put it at the end of the module by default. 
+			update_post_meta( $this->lesson_id, $order_module_key, 99 );
 		}
 	}
 

--- a/wp-content/plugins/sensei/includes/class-sensei-lesson.php
+++ b/wp-content/plugins/sensei/includes/class-sensei-lesson.php
@@ -345,7 +345,6 @@ class Sensei_Lesson {
 		if ( 'lesson' != get_post_type( $post ) ) {
 			return;
 		}
-
 		$lesson_id = absint( $post->ID );
 
 		if ( $new_status !== 'publish' ) {


### PR DESCRIPTION
## Bug squashed: Sensei bug causing ordering issues when creating and updating lessons

### Builder(s)
Chris Muller

### Branch
foo/lesson-edit-ordering

### Context
The FW team found that the lessons were being automatically ordered to the beginning of modules when created and when editing and saving. This was frustrating and unhelpful. After investigation, we found a Sensei bug that was resulting in this. 

### Changes
- Fix the Sensei lesson ordering within modules after creating and also saving lessons
The Sensei bug was squashed.

### Testing
- Testing has been done on local for creating new lessons and editing existing lessons. Shouldn't need further testing