### PR TITLE
Fix unit header alignment

### DIFF
--- a/wp-content/themes/fundawande/templates/lms/single-module.twig
+++ b/wp-content/themes/fundawande/templates/lms/single-module.twig
@@ -9,7 +9,7 @@
     <div class="wrapper single-module-wrapper  background-secondary" id="page-wrapper" xmlns="http://www.w3.org/1999/html">
 
         <div class = "container-fluid ">
-            <div class = "row module-title justify-content-between align-items-center  background-primary">
+            <div class = "row module-title justify-content-start align-items-center background-primary">
                 <div class = "col-12 col-md-2 text-center">
                     <a id = "back-to-modules" class = "button-secondary module-btn-outline-{{module_number}} py-4 my-4" href = "{{course_link}}">
                         <span class="mb-0 mb-md-2 d-inline-block">{{source('/assets/arrow_left.svg')}}</span>
@@ -17,7 +17,7 @@
                         <span class = "button-text-width-limit">{{attribute(options, lang.prefix~'back_to_modules_text')}}</span>
                     </a>
                 </div>
-                <div class = "col-12 col-md-10 text-center my-4">
+                <div class = "col-12 col-md-8 text-center my-4">
                     <h4 class = "mt-4">Module {{module_number}}</h4>
                     <h1 class = "text-center text-bold mb-4">{{module_title }}</h1>
                 </div>


### PR DESCRIPTION
### Context
The unit header was not aligned to the centre of the page. 

### Changes
Changed the grid slightly and added justify-start instead of justify-between. 