### PR TITLE
Add submission logic for multi-line quizzes

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-coaching.php
@@ -174,7 +174,6 @@ class FundaWande_Coaching {
                     // }
 
                     // update the comment post meta for feedback boolean
-                    error_log(print_r($assessment_feedback,true));
 
                 } else {
                     $assessment_feedback =  false;

--- a/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
@@ -327,7 +327,7 @@ class FundaWande_Quiz {
             }
 
             $type = Sensei()->question->get_question_type( $question->ID );
-            error_log($type);
+            // error_log($type);
             
             switch ($type){
                 case "boolean":

--- a/wp-content/plugins/fundawande/templates/question_type-needs-feedback.php
+++ b/wp-content/plugins/fundawande/templates/question_type-needs-feedback.php
@@ -26,22 +26,34 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     $user_id = get_current_user_id();
     $completed = FundaWande()->quiz->user_completed_lesson($lesson_id,$user_id);
 
-?>
+    ?>
 <?php if ( !empty($question_data[ 'answer_media_url' ]) || !empty($question_data[ 'user_answer_entry' ]) ){ ?>
 <div class="background-secondary p-4 mb-4">
     <h4 class="lbreaker-lms-purple mb-3">Summary</h4>
     <?php if ($completed) { ?>
-        <p><b>Activity status:</b> Completed <img class="ml-2" src="/wp-content/themes/startupschool/assets/lms/Tick_green.svg"></p>
+        <p><b>Activity status:</b> Completed <img class="ml-2" src="/wp-content/themes/fundawande/assets/tick_green.svg"></p>
 
     <?php } else { ?>
         <p><b>Activity status:</b> Submitted</p>
 
+    <?php }
+    
+    $has_feedback = FundaWande()->quiz->user_can_view_feedback($lesson_id,$user_id);
+
+    
+    ?>
+    <?php if ( $has_feedback) { ?>
+        <p><b>Feedback status:</b> Feedback given <img class="ml-2" src="/wp-content/themes/fundawande/assets/tick_green.svg"></p>
+        <p><em>Thank you for your submission, please see your feedback below.</em></p>
+
+    <?php } else { ?>
+        <p><b>Feedback status:</b> Awaiting feedback</p>
     <?php } ?>
+    <p><b>Question: </b><?php echo $question_data[ 'title' ]; ?></p>
+
 
     <?php if ( !empty($question_data[ 'answer_media_url' ])  &&  $question_data[ 'answer_media_filename' ]  ) { ?>
-        <p><b>Feedback status:</b> Feedback given <img class="ml-2" src="/wp-content/themes/startupschool/assets/lms/Tick_green.svg"></p>
-        <p><em>Thank you for your submission, please see your feedback below.</em></p>
-        <p class="submitted_file">
+            <p class="submitted_file">
 
             <?php
 
@@ -53,8 +65,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         </p>
 
     <?php } elseif ($question_data[ 'user_answer_entry' ])  {?>
-        <p><b>Feedback status:</b> Feedback given <img class="ml-2" src="/wp-content/themes/startupschool/assets/lms/Tick_green.svg"></p>
-        <p><em>Thank you for your submission, please see your feedback below.</em></p>
         <p class="submitted_file">
 
             <?php
@@ -75,12 +85,15 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         ?>
     </form>
 <?php } ?>
-<?php } ?>
+<?php } 
+
+$question_answer_feedback = Sensei()->quiz->get_user_question_feedback($lesson_id, $question_id, $user_id);
+
+    if ($question_answer_feedback && !empty($question_answer_feedback) ) {
+        ?>
 <div class="p-3 my-4" style="border:1px solid #d8d8d8;">
     <?php
-    $question_answer_feedback = Sensei()->quiz->get_user_question_feedback($lesson_id, $question_id, $user_id);
-
-    if ($question_answer_feedback ) {
+    
         echo ' <h4 class="lbreaker-lms-purple  mb-3">Our feedback for you</h4>';
 
     ?>
@@ -89,7 +102,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     </div>
      
-    <?php } ?>
+  
 </div>
+<?php } ?>
 <?php
 ?>

--- a/wp-content/plugins/fundawande/templates/single-quiz.php
+++ b/wp-content/plugins/fundawande/templates/single-quiz.php
@@ -36,14 +36,14 @@
 			<?php if ( sensei_quiz_has_questions() ): ?>
 			<?php
                 // Check whether feedback has been released
-                $has_feedback = FundaWande()->quiz->user_can_view_feedback(Sensei()->quiz->data->quiz_lesson, get_current_user_id());
+                $needs_feedback = FundaWande()->quiz->assessment_needs_feedback(Sensei()->quiz->data->quiz_lesson);
                 $is_submitted = FundaWande()->quiz->user_has_submitted(Sensei()->quiz->data->quiz_lesson, get_current_user_id());
 
                 ?>
 
 
                 <?php
-                if ($has_feedback && $is_submitted) { ?>
+                if ($needs_feedback && $is_submitted) { ?>
 					
 
 						<?php while ( sensei_quiz_has_questions() ): sensei_setup_the_question(); ?>

--- a/wp-content/themes/fundawande/assets/tick_green.svg
+++ b/wp-content/themes/fundawande/assets/tick_green.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="29px" height="23px" viewBox="0 0 29 23" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+    <title>Tick Copy</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <g id="5.-Lesson---Submitted-Activity" transform="translate(-322.000000, -631.000000)" stroke-width="3.67339618" stroke="#7ED321">
+            <g id="Main-Content" transform="translate(45.000000, 381.000000)">
+                <g id="Instructions" transform="translate(0.000000, 126.000000)">
+                    <polyline id="Tick-Copy" points="280 137.880002 287.849241 144 303 127"></polyline>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Fixes #61 

### Requested by:
Funda Wande Team

### Contributor(s):
@cwbmuller Chris Muller

### Branch:
foo/multi-line

### Context:
The multi-line question types were not accounted for in the submission logic given they needed to manually reviewed - like file upload questions. They needed to follow the same logic as the file upload questions and be reviewed via the coach dashboard.

### Change(s):
- Added logic to tell users the submission is received:
![Screenshot 2019-03-26 at 15 48 17](https://user-images.githubusercontent.com/1436311/55003682-83dc4e80-4fe1-11e9-89eb-fdcd30830a09.png)

- Add logic to tell users that the activity is now complete and they can review the feedback once a coach has reviewed the activity
![Screenshot 2019-03-26 at 15 49 00](https://user-images.githubusercontent.com/1436311/55003684-8474e500-4fe1-11e9-8b44-58779e59d12a.png)

### Change significance:
Medium

### Pre-release Testing:
- Tested submission of multi-line question
- Tested reviewing of multi-line activity

### Post-release Testing:
- FW team to test a multi-line activity

### NB
Activities cannot include both auto-graded and manually graded questions. They need to be EITHER Manual (multi-line / file submission) OR Auto (MCQ, drag-and-drop etc.)