### PR TITLE
Change logic for current lesson when on lesson page

### DIFF
--- a/wp-content/themes/fundawande/templates/lms/embeds/lesson-progress-mobile.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/lesson-progress-mobile.twig
@@ -16,10 +16,14 @@
                         <hr class="m-0">
                         <div class="my-4 row no-gutters px-4 flex-column">
                         {% for lesson in sub_unit_meta.unit_lessons %}
-                            <div class = "col lesson-progress-divider {% if lesson.complete or lesson.current %}module-divider-before-{{module_number}}{% endif %}"></div>
+                            {% set lesson_current = false %}
+                            {% if lesson.ID == post.ID or lesson.ID == quiz_lesson.ID %}
+                                {% set lesson_current = true %}
+                            {% endif %}
+                            <div class = "col lesson-progress-divider {% if lesson.complete or lesson_current %}module-divider-before-{{module_number}}{% endif %}"></div>
                             {# TODO add back limit #}
-                            {#<a {%  if lesson.complete or lesson.current %}href = "{{function('get_post_permalink', lesson.ID)}}"{% endif %} class="lesson-progress-marker d-flex align-items-center col-auto module-svg-fill-{{ module_number }} {%  if lesson.complete  %}complete {% endif %} {%  if lesson.current  %}module-border-{{ module_number }} current{% endif %} {%  if not (lesson.complete or lesson.current ) %}disabled{% endif %}">#}
-                            <a href = "{{function('get_post_permalink', lesson.ID)}}" class="lesson-progress-marker d-flex align-items-center col-auto {%  if lesson.complete  %}complete module-svg-icon-fill-{{ module_number }}{% endif %} {%  if lesson.current  %}module-border-{{ module_number }} module-svg-fill-{{ module_number }} current{% endif %}">
+                            {#<a {%  if lesson.complete or lesson_current %}href = "{{function('get_post_permalink', lesson.ID)}}"{% endif %} class="lesson-progress-marker d-flex align-items-center col-auto module-svg-fill-{{ module_number }} {%  if lesson.complete  %}complete {% endif %} {%  if lesson_current  %}module-border-{{ module_number }} current{% endif %} {%  if not (lesson.complete or lesson_current ) %}disabled{% endif %}">#}
+                            <a href = "{{function('get_post_permalink', lesson.ID)}}" class="lesson-progress-marker d-flex align-items-center col-auto {%  if lesson.complete  %}complete module-svg-icon-fill-{{ module_number }}{% endif %} {%  if lesson_current  %}module-border-{{ module_number }} module-svg-fill-{{ module_number }} current{% endif %}">
                                 {% set image = source('assets/lms/lesson_icons/' ~ lesson.icon ~ '.svg', ignore_missing = true) %}
                                 {% if image %}
                                     {{ source('assets/lms/lesson_icons/' ~ lesson.icon ~ '.svg') }}
@@ -27,7 +31,7 @@
                                     {{ source('assets/lms/lesson_icons/book-front.svg') }}
                                 {% endif %}
                                 <div class="pl-2 d-flex flex-column lesson-progress-text">
-                                    <span class="{%  if lesson.current  %}module-text-{{ module_number }}{% endif %}">{%  if lesson.current  %}Current{% endif %}</span>
+                                    <span class="{%  if lesson_current  %}module-text-{{ module_number }}{% endif %}">{%  if lesson_current  %}Current{% endif %}</span>
                                     <span class = "">{{lesson.title}}</span>
                                 </div>
                             </a>
@@ -45,8 +49,12 @@
             <div class = "col-auto module-bg-{{module_number}} lesson-progress-module-number  px-3 d-block"><h4 class = "m-0 text-white">{{unit_number}}.{{ lesson_number }}</h4></div>
             <div class=" lesson-progress-markers px-3 w-100 row no-gutters align-items-center flex-row">
             {% for lesson in sub_unit_meta.unit_lessons %}
-                <div class = "col lesson-progress-divider {% if lesson.complete or lesson.current %}module-divider-before-{{module_number}}{% endif %}"></div>
-                <div class = "col-auto  lesson-progress-marker {% if lesson.complete or lesson.current %}module-bg-{{module_number}}{% endif %} {% if lesson.current %}current module-border-{{module_number}}{% endif %} text-center p-2"></div>
+                {% set lesson_current = false %}
+                {% if lesson.ID == post.ID or lesson.ID == quiz_lesson.ID %}
+                    {% set lesson_current = true %}
+                {% endif %}
+                <div class = "col lesson-progress-divider {% if lesson.complete or lesson_current %}module-divider-before-{{module_number}}{% endif %}"></div>
+                <div class = "col-auto  lesson-progress-marker {% if lesson.complete or lesson_current %}module-bg-{{module_number}}{% endif %} {% if lesson_current %}current module-border-{{module_number}}{% endif %} text-center p-2"></div>
             {% endfor %}
             </div>
         </div>

--- a/wp-content/themes/fundawande/templates/lms/embeds/lesson-sidebar.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/lesson-sidebar.twig
@@ -15,10 +15,14 @@
             <hr class="m-0">
             <div class="my-4 row no-gutters px-4 flex-column">
             {% for lesson in sub_unit_meta.unit_lessons %}
-                <div class = "col lesson-progress-divider {% if lesson.complete or lesson.current %}module-divider-before-{{module_number}}{% endif %}"></div>
+                {% set lesson_current = false %}
+                {% if lesson.ID == post.ID or lesson.ID == quiz_lesson.ID %}
+                    {% set lesson_current = true %}
+                {% endif %}
+                <div class = "col lesson-progress-divider {% if lesson.complete or lesson_current %}module-divider-before-{{module_number}}{% endif %}"></div>
                 {# TODO add back limit #}
-                {#<a {%  if lesson.complete or lesson.current %}href = "{{function('get_post_permalink', lesson.ID)}}"{% endif %} class="lesson-progress-marker d-flex align-items-center col-auto module-svg-fill-{{ module_number }} {%  if lesson.complete  %}complete {% endif %} {%  if lesson.current  %}module-border-{{ module_number }} current{% endif %} {%  if not (lesson.complete or lesson.current ) %}disabled{% endif %}">#}
-                <a href = "{{function('get_post_permalink', lesson.ID)}}" class="lesson-progress-marker d-flex align-items-center col-auto  {%  if lesson.complete  %}complete module-svg-icon-fill-{{ module_number }}{% endif %} {%  if lesson.current  %}module-border-{{ module_number }} module-svg-fill-{{ module_number }} current{% endif %}">
+                {#<a {%  if lesson.complete or lesson_current %}href = "{{function('get_post_permalink', lesson.ID)}}"{% endif %} class="lesson-progress-marker d-flex align-items-center col-auto module-svg-fill-{{ module_number }} {%  if lesson.complete  %}complete {% endif %} {%  if lesson_current  %}module-border-{{ module_number }} current{% endif %} {%  if not (lesson.complete or lesson_current ) %}disabled{% endif %}">#}
+                <a href = "{{function('get_post_permalink', lesson.ID)}}" class="lesson-progress-marker d-flex align-items-center col-auto  {%  if lesson.complete  %}complete module-svg-icon-fill-{{ module_number }}{% endif %} {%  if lesson_current  %}module-border-{{ module_number }} module-svg-fill-{{ module_number }} current{% endif %}">
                     {% set image = source('assets/lms/lesson_icons/' ~ lesson.icon ~ '.svg', ignore_missing = true) %}
                     {% if image %}
                         {{ source('assets/lms/lesson_icons/' ~ lesson.icon ~ '.svg') }}
@@ -26,7 +30,7 @@
                         {{ source('assets/lms/lesson_icons/book-front.svg') }}
                     {% endif %}
                     <div class="pl-2 d-flex flex-column lesson-progress-text">
-                        <span class="{%  if lesson.current  %}module-text-{{ module_number }}{% endif %}">{%  if lesson.current  %}Current{% endif %}</span>
+                        <span class="{%  if lesson_current  %}module-text-{{ module_number }}{% endif %}">{%  if lesson_current  %}Current{% endif %}</span>
                         <span class = "title">{{lesson.title}}</span>
                     </div>
                 </a>
@@ -42,8 +46,12 @@
             </div>
             <div class="my-4 row no-gutters align-items-center flex-column">
             {% for lesson in sub_unit_meta.unit_lessons %}
-                <div class = "col lesson-progress-divider {% if lesson.complete or lesson.current %}module-divider-before-{{module_number}}{% endif %}"></div>
-                <div class = "col-auto  lesson-progress-marker {% if lesson.complete or lesson.current %}module-bg-{{module_number}}{% endif %} {% if lesson.current %}current module-border-{{module_number}}{% endif %} text-center p-2"></div>
+                {% set lesson_current = false %}
+                {% if lesson.ID == post.ID or lesson.ID == quiz_lesson.ID %}
+                    {% set lesson_current = true %}
+                {% endif %}
+                <div class = "col lesson-progress-divider {% if lesson.complete or lesson_current %}module-divider-before-{{module_number}}{% endif %}"></div>
+                <div class = "col-auto  lesson-progress-marker {% if lesson.complete or lesson_current %}module-bg-{{module_number}}{% endif %} {% if lesson_current %}current module-border-{{module_number}}{% endif %} text-center p-2"></div>
             {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
### Requested by:
Pango Team

### Contributor(s):
@cwbmuller  Chris Muller

### Branch:
fix/current-lesson

### Context:
The Pango Team noticed that since the sequential flow of lessons was removed the current lesson logic did not make sense when on a lesson (it could be set to a lesson you weren't on). This was confusing to users (us).

### Change(s):
- Changed the highlighted lesson to the lesson that the user was currently viewing
![Screenshot 2019-03-26 at 16 01 46](https://user-images.githubusercontent.com/1436311/55004268-96a35300-4fe2-11e9-86be-8a711be5cfcb.png)
![Screenshot 2019-03-26 at 16 01 53](https://user-images.githubusercontent.com/1436311/55004269-973be980-4fe2-11e9-9759-66b68c3d44b7.png)


### Change significance:
Small

### Pre-release Testing:
- Tested on desktop for lesson
- Tested on desktop for quiz
- Tested on mobile for lesson
- Tested on mobile for quiz

### Post-release Testing:
- N/A