### PR TITLE
Fix issue with incorrectly graded quizzes

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
@@ -228,15 +228,25 @@ class FundaWande_Quiz {
      */
     public function check_correctly_submitted_quiz($lesson_id,$user_id) {
        
-        $lesson_completed = false;
+        // Set quiz to correct by default
+        $quiz_correct = true;
 
+        // Get the lesson status
         $lesson_status = Sensei_Utils::user_lesson_status($lesson_id,$user_id);
-        if (isset($lesson_status) && $lesson_status->comment_approved == 'complete')  {
-            $lesson_completed = true;
+        
+        // If lesson status exists
+        if ($lesson_status)  {
+            // Check whether the quiz lesson status is incorrectly set to compelte
+            if ($lesson_status->comment_approved == 'complete') {
+                // If true then this quiz is incorrect
+                $quiz_correct = false;
+                // Reset this lesson for this user so they can complete it correctly
+                Sensei_Utils::sensei_remove_user_from_lesson($lesson_id,$user_id);
+            }
         }
 
-        return false;
-       
+        // Return the result
+        return $quiz_correct;
     }
 
     /**

--- a/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-quiz.php
@@ -219,6 +219,27 @@ class FundaWande_Quiz {
     }
 
     /**
+     * Check whether a quiz has been graded correctly.
+     *
+     * @param integer $lesson_id the ID of the activity (lesson) to check.
+     * @param integer $user_id the ID of the user to check.
+     * 
+     * @return boolean true or false.
+     */
+    public function check_correctly_submitted_quiz($lesson_id,$user_id) {
+       
+        $lesson_completed = false;
+
+        $lesson_status = Sensei_Utils::user_lesson_status($lesson_id,$user_id);
+        if (isset($lesson_status) && $lesson_status->comment_approved == 'complete')  {
+            $lesson_completed = true;
+        }
+
+        return false;
+       
+    }
+
+    /**
      * Check whether activity feedback has been released to the user.
      *
      * @return boolean true or false.

--- a/wp-content/themes/fundawande/sensei/single-quiz.php
+++ b/wp-content/themes/fundawande/sensei/single-quiz.php
@@ -31,8 +31,10 @@ if (class_exists('Timber')) {
     // Get the quiz lesson ID
     $lesson_id = $post->_quiz_lesson;
     $lesson = new TimberPost($lesson_id);
-    
     $context['quiz_lesson'] =  $lesson;
+
+    // Add check to see that quiz is correctly set for the user
+    $context['quiz_correctly'] = FundaWande()->quiz->check_correctly_submitted_quiz($lesson_id,$user->ID);
 
     $current_course_id =  FundaWande()->lms->fw_get_current_course_id($user->ID);
     $lesson_course_ID = Sensei()->lesson->get_course_id($lesson_id);

--- a/wp-content/themes/fundawande/sensei/single-quiz.php
+++ b/wp-content/themes/fundawande/sensei/single-quiz.php
@@ -31,6 +31,7 @@ if (class_exists('Timber')) {
     // Get the quiz lesson ID
     $lesson_id = $post->_quiz_lesson;
     $lesson = new TimberPost($lesson_id);
+    
     $context['quiz_lesson'] =  $lesson;
 
     $current_course_id =  FundaWande()->lms->fw_get_current_course_id($user->ID);

--- a/wp-content/themes/fundawande/templates/lms/single-quiz.twig
+++ b/wp-content/themes/fundawande/templates/lms/single-quiz.twig
@@ -21,6 +21,7 @@
 {# Twig block to be included in Base.twig #}
 {% block content %}
     <div class="wrapper single-lesson-wrapper" id="page-wrapper" xmlns="http://www.w3.org/1999/html">
+            {{ dump(quiz_correctly)}}
 
         {# Include mobile progress component #}
         {% include '/lms/embeds/lesson-progress-mobile.twig' %}

--- a/wp-content/themes/fundawande/templates/lms/single-quiz.twig
+++ b/wp-content/themes/fundawande/templates/lms/single-quiz.twig
@@ -21,7 +21,6 @@
 {# Twig block to be included in Base.twig #}
 {% block content %}
     <div class="wrapper single-lesson-wrapper" id="page-wrapper" xmlns="http://www.w3.org/1999/html">
-            {{ dump(quiz_correctly)}}
 
         {# Include mobile progress component #}
         {% include '/lms/embeds/lesson-progress-mobile.twig' %}


### PR DESCRIPTION
Fixes issue of incorrectly graded quizzes

### Requested by:
FW Team (Mel)

### Contributor(s):
@cwbmuller Chris Muller

### Branch:
foo/quiz-checker

### Context:
Mel found that some quizzes were acting as submitted, however no answers had been given/saved. 

After investigation it was found that the quizzes were marked as complete lessons due to the complicated architecture of lessons and quizzes in Sensei. This meant that if a lesson was completed by a user before it became a quiz (ie: questions were added), the quiz was then incorrectly graded going forwards.

### Change(s):
A checker was added to quizzes to check whether they were incorrectly graded and if so, they are reset so the user can submit them correctly.

### Change significance:
Low

### Pre-release Testing:
Tested and working as expected

### Post-release Testing:
Mel needs to visit the quizzes she was experiencing issue on.