### PR TITLE
Add Data Studio Insights

### DIFF
--- a/wp-content/themes/fundawande/template-insights.php
+++ b/wp-content/themes/fundawande/template-insights.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ *Template Name: Insights Page Template
+ *
+ * @package Pango
+ */
+
+if (!is_user_logged_in()) {
+    wp_redirect(wp_login_url(get_permalink()));
+    exit();
+}
+
+if ( class_exists( 'Timber' ) ) {
+
+    $context = Timber::get_context();
+    $post = new TimberPost();
+    $context['post'] = $post;
+
+    // Assign current user to context
+    $user = new TimberUser();
+    $context['user'] = $user;
+
+    Timber::render(array('template-insights.twig', 'page.twig'), $context);
+}

--- a/wp-content/themes/fundawande/templates/template-insights.twig
+++ b/wp-content/themes/fundawande/templates/template-insights.twig
@@ -1,0 +1,19 @@
+{# Choose base on which to extend this template #}
+{% extends "base.twig" %}
+
+{# Import macros for use in this template #}
+{% import "mixins.twig" as mixin %}
+
+{# Twig block to be included in Base.twig #}
+{% block content %}
+    <div class="wrapper contacts-wrapper background-secondary" id="page-wrapper" xmlns="http://www.w3.org/1999/html">
+        <div class="container my-4 w-100">
+            {{post.content}}
+        </div> <!-- end container -->
+    </div><!-- end #wrapper -->
+
+    {# Embed footer template #}
+    {% embed "embeds/footer.twig" %}{% endembed %}
+{% endblock %}
+
+


### PR DESCRIPTION
### Requested by:
James Lees

### Contributor(s):
Jason Tame

### Branch:
foo/insights

### Context:
The data studio view has been set up by Chris, this PR just adds a simple template on which the data studio can be embedded

### Change(s):
Add insights template

### Change significance:
Low
