### PR TITLE
Unit completion bug workaround

### DIFF
--- a/wp-content/plugins/fundawande/includes/class-fundawande-units.php
+++ b/wp-content/plugins/fundawande/includes/class-fundawande-units.php
@@ -68,7 +68,7 @@ class FundaWande_Units {
         }
 
 
-        $unit_lessons = Sensei()->modules->get_lessons( $course_id , $unit_id);
+        $unit_lessons = FundaWande()->lessons->get_lessons( $course_id , $unit_id);
 
         $completed = 0;
         $total = 0;

--- a/wp-content/themes/fundawande/taxonomy-module.php
+++ b/wp-content/themes/fundawande/taxonomy-module.php
@@ -28,8 +28,9 @@ if (class_exists('Timber')) {
     // Get the modules units to visualise on the module page
     $context['units'] = $units;
 
+    // When the page reloads, re-run the unit progress function to make sure that completed units are updated properly. 
     foreach ($units as $key => $unit) {
-     $unit_progress = FundaWande()->units->fw_unit_progress($unit->ID, $current_course_id);
+        FundaWande()->units->fw_unit_progress($unit->ID, $current_course_id);
     }
 
     Timber::render(array('lms/single-module.twig', 'page.twig'), $context);

--- a/wp-content/themes/fundawande/taxonomy-module.php
+++ b/wp-content/themes/fundawande/taxonomy-module.php
@@ -28,5 +28,9 @@ if (class_exists('Timber')) {
     // Get the modules units to visualise on the module page
     $context['units'] = $units;
 
+    foreach ($units as $key => $unit) {
+     $context['unit_progress'] = FundaWande()->units->fw_unit_progress($unit->ID, $current_course_id);
+    }
+
     Timber::render(array('lms/single-module.twig', 'page.twig'), $context);
 }

--- a/wp-content/themes/fundawande/taxonomy-module.php
+++ b/wp-content/themes/fundawande/taxonomy-module.php
@@ -29,7 +29,7 @@ if (class_exists('Timber')) {
     $context['units'] = $units;
 
     foreach ($units as $key => $unit) {
-     $context['unit_progress'] = FundaWande()->units->fw_unit_progress($unit->ID, $current_course_id);
+     $unit_progress = FundaWande()->units->fw_unit_progress($unit->ID, $current_course_id);
     }
 
     Timber::render(array('lms/single-module.twig', 'page.twig'), $context);

--- a/wp-content/themes/fundawande/taxonomy-module.php
+++ b/wp-content/themes/fundawande/taxonomy-module.php
@@ -24,8 +24,9 @@ if (class_exists('Timber')) {
     $context['module_number'] = get_term_meta($term->ID, 'module_number', true);
     $context['module_title'] = get_term_meta($term->ID, 'module_title', true);
 
+    $units = FundaWande()->modules->get_module_units($term->ID,$current_course_id);
     // Get the modules units to visualise on the module page
-    $context['units'] = FundaWande()->modules->get_module_units($term->ID,$current_course_id);
+    $context['units'] = $units;
 
     Timber::render(array('lms/single-module.twig', 'page.twig'), $context);
 }


### PR DESCRIPTION
### Requested by:
FW Team

### Contributor(s):
Jason Tame

### Branch:
bug/unit-completion

### Context:
Sometimes completing the final lesson in a unit does not update the unit completion status. This leads to confusion as the user thinks they have not done something correctly. 

### Change(s):
When the modules page is reloaded, the unit completion status check runs for each unit within that module. Units that are supposed to be complete are marked as complete.

**NB: This doesn't solve the underlying issue of why the status isn't updated when the lesson is completed, but it is a workaround that solves the user-facing consequence of the bug.** 


### Change significance:
Low

### Pre-release Testing:
Completed lessons with various dummy users and reloaded the unit page if the unit completion status was not updated. It was properly updated on each test

### Post-release Testing:
Make sure that all units which are supposed to be completed are indeed completed, i.e. check for any edge cases which have been missed. 