### PR TITLE
Add new legal page template and fix footer display bugs

### DIFF
--- a/wp-content/themes/fundawande/template-legal.php
+++ b/wp-content/themes/fundawande/template-legal.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Template Name: Legal Page Template
+ *
+ * @package Pango
+ * 
+ * This template is used for any legal documentation such as the terms and conditions and privacy policy.
+ */
+
+if ( class_exists( 'Timber' ) ) {
+    if (!is_user_logged_in()) {
+        wp_redirect(wp_login_url(get_permalink()));
+        exit();
+    }
+    $context = Timber::get_context();
+    $post = new TimberPost();
+    $context['post'] = $post;
+
+    Timber::render(array('template-legal.twig', 'page.twig'), $context);
+
+}

--- a/wp-content/themes/fundawande/templates/embeds/footer.twig
+++ b/wp-content/themes/fundawande/templates/embeds/footer.twig
@@ -3,36 +3,27 @@
 #
 #}
 
-{# Start footer #}
-
 <div class="footer-wrapper" id="wrapper-footer">
     <footer id="site-footer" class="py-2">
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-12">
-                    <div class="container-fluid">
-                        <div class="row justify-content-md-between justify-content-center">
-                            <!-- Copyright Info -->
-                            <div class="col-auto align-self-center ">
-                                <span class="footer-nav-text">&copy; Funda Wande</span>
-                            </div>
-                            <!-- Footer Links -->
-                            <div class="col-md-auto col-12 align-self-center flex-first flex-md-last mt-3 mt-md-0 text-center">
-                            {% for footer_link in options.footer_links %}
-                                <a target="_blank" class="align-self-center d-md-inline-block d-block  pl-md-4 pr-md-0 px-2" href="{{footer_link.link}}">
-                                    {% if lang.id == 'eng' %} 
-                                        {{footer_link.eng_title}} 
-                                    {% else %} 
-                                        {{footer_link.xho_title}} 
-                                    {% endif %}
-                                </a>
-                            {% endfor %}
-                            </div>
-                        </div>
-                    </div>
+        <div class="container">
+            <div class="row justify-content-md-between justify-content-center">
+                <!-- Copyright Info -->
+                <div class="col-auto align-self-center ">
+                    <span class="footer-nav-text">&copy; Funda Wande</span>
+                </div>
+                <!-- Footer Links -->
+                <div class="col-md-auto col-12 align-self-center flex-first flex-md-last mt-3 mt-md-0 text-center">
+                {% for footer_link in options.footer_links %}
+                    <a target="_blank" class="align-self-center d-md-inline-block d-block  pl-md-4 pr-md-0 px-2" href="{{footer_link.link}}">
+                        {% if lang.id == 'eng' %} 
+                            {{footer_link.eng_title}} 
+                        {% else %} 
+                            {{footer_link.xho_title}} 
+                        {% endif %}
+                    </a>
+                {% endfor %}
                 </div>
             </div>
         </div>
     </footer>
-    <!-- #site-footer -->
 </div>

--- a/wp-content/themes/fundawande/templates/embeds/footer.twig
+++ b/wp-content/themes/fundawande/templates/embeds/footer.twig
@@ -15,11 +15,7 @@
                 <div class="col-md-auto col-12 align-self-center flex-first flex-md-last mt-3 mt-md-0 text-center">
                 {% for footer_link in options.footer_links %}
                     <a target="_blank" class="align-self-center d-md-inline-block d-block  pl-md-4 pr-md-0 px-2" href="{{footer_link.link}}">
-                        {% if lang.id == 'eng' %} 
-                            {{footer_link.eng_title}} 
-                        {% else %} 
-                            {{footer_link.xho_title}} 
-                        {% endif %}
+                        {{ lang.id == 'eng' ? footer_link.eng_title : footer_link.xho_title }}
                     </a>
                 {% endfor %}
                 </div>

--- a/wp-content/themes/fundawande/templates/template-legal.twig
+++ b/wp-content/themes/fundawande/templates/template-legal.twig
@@ -1,0 +1,30 @@
+{# Choose base on which to extend this template #}
+{% extends "base.twig" %}
+
+{# Import macros for use in this template #}
+{% import "mixins.twig" as mixin %}
+
+{# Twig block to be included in Base.twig #}
+{% block content %}
+    <div class="wrapper legal-wrapper" id="page-wrapper" xmlns="http://www.w3.org/1999/html">
+        <!-- Page Header -->
+        <div class = "container-fluid background-primary">
+            <div class = "row" >
+                <div class = "col-12">
+                    <h1 class="text-center m-4">{{post.get_field(lang.prefix~'page_title')}}</h1>
+                </div>
+            </div>
+        </div>
+
+        <!-- Content Section -->
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    {{post.get_field(lang.prefix~'content')}}
+                </div>
+            </div>
+        </div>
+    </div>
+    {# Embed footer template #}
+    {% embed "embeds/footer.twig" %}{% endembed %}
+{% endblock %}

--- a/wp-content/themes/fundawande/templates/template-profile.twig
+++ b/wp-content/themes/fundawande/templates/template-profile.twig
@@ -50,4 +50,6 @@
             </div>
         </div>
     </div><!-- #wrapper -->
+    {# Embed footer template #}
+    {% embed "embeds/footer.twig" %}{% endembed %}
 {% endblock %}


### PR DESCRIPTION
### Contributor(s):
Jason Tame

### Branch:
fix/footer

### Context:
In order for the FW team to add legal documents such as Ts and Cs and the privacy policy, a template was needed which is populated by some ACF fields in order to make it easy to add the content in both English and isiXhosa

### Change(s):
This PR adds a template called 'legal page template' which can be used to add any legal pages to the site. 

It also fixes the footer code so that items are displayed correctly

### Change significance:
Low