### PR TITLE
Add image grid as a content type

### DIFF
--- a/wp-content/themes/fundawande/templates/lms/content-types/image/image-grid.twig
+++ b/wp-content/themes/fundawande/templates/lms/content-types/image/image-grid.twig
@@ -1,6 +1,6 @@
 <!-- Content Type: Image Grid -->
 {% for image in content.image_grid %}
-    {% set numImages = content.pdf_grid|length %}
+    {% set numImages = content.image_grid|length %}
     {% if numImages == 2 %}
         {% set imgCols = "col-md-6" %}
     {% elseif numImages == 3 %}
@@ -9,6 +9,6 @@
         {% set imgCols = "col-md-3" %}
     {% endif %}
 
-    {{mixin.imgGridItem(imgCols, image.file, image.holding_image, image.caption, module_number)}}
+    {{mixin.imgGridItem(imgCols, image.file, image.caption, module_number)}}
 
 {% endfor %}

--- a/wp-content/themes/fundawande/templates/lms/content-types/image/image-grid.twig
+++ b/wp-content/themes/fundawande/templates/lms/content-types/image/image-grid.twig
@@ -1,0 +1,14 @@
+<!-- Content Type: Image Grid -->
+{% for image in content.image_grid %}
+    {% set numImages = content.pdf_grid|length %}
+    {% if numImages == 2 %}
+        {% set imgCols = "col-md-6" %}
+    {% elseif numImages == 3 %}
+        {% set imgCols = "col-md-4" %}
+    {% elseif numImages == 4 %}
+        {% set imgCols = "col-md-3" %}
+    {% endif %}
+
+    {{mixin.imgGridItem(imgCols, image.file, image.holding_image, image.caption, module_number)}}
+
+{% endfor %}

--- a/wp-content/themes/fundawande/templates/lms/embeds/lesson/lesson-content.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/lesson/lesson-content.twig
@@ -55,6 +55,9 @@
                     {# Pulled right image #}
                 {% elseif content.acf_fc_layout == 'image_pulled_right' %}
                     {% include '/lms/content-types/image/image-pulled-right.twig' %}
+                    {# Image Grid #}
+                {% elseif content.acf_fc_layout == 'image_grid' %}
+                    {% include '/lms/content-types/image/image-grid.twig' %}
 
                 {# PDF Content Types #}
                     {# PDF Container Width #}

--- a/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-end-lesson.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-end-lesson.twig
@@ -3,7 +3,7 @@
 {% embed "embeds/modals/modal-global.twig" %}
   {# Add quiz outcome header to modal #}
   {% block modal_header %}
-    <h5 class="modal-title">
+    <h5 class="modal-title text-center">
       <span class = "module-svg-icon-fill-{{module_number}} px-2">{{source('/assets/trophy_icon.svg')}}</span>
       <strong>{{attribute(options, lang.prefix~'well_done_text')}}, {{user.display_name}}!</strong>
     </h5>
@@ -14,8 +14,9 @@
   {% endblock %}
   {# Add quiz modal content to modal #}
   {% block modal_body %}
-
-    {{post.get_field('custom_feedback_message')}}
+    <p class="text-center">
+      {{post.get_field('custom_feedback_message')}}    
+    </p>
 
   {% endblock %}
 

--- a/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-end-unit.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/modals/modal-end-unit.twig
@@ -3,7 +3,7 @@
 {% embed "embeds/modals/modal-global.twig" %}
   {# Add quiz outcome header to modal #}
   {% block modal_header %}
-    <h5 class="modal-title">
+    <h5 class="modal-title text-center">
       <span class = "module-svg-icon-fill-{{module_number}} px-2">{{source('/assets/trophy_icon.svg')}}</span>
       <strong>{{attribute(options, lang.prefix~'well_done_text')}}, {{user.display_name}}!</strong>
     </h5>
@@ -15,7 +15,9 @@
   {# Add quiz modal content to modal #}
   {% block modal_body %}
 
-      <p>{{attribute(options, lang.prefix~'unit_completed_text')}} <span class="text-bold">{{sub_unit_meta.unit_title}}</span></p>
+      <p class="text-center">
+        {{attribute(options, lang.prefix~'unit_completed_text')}} <span class="text-bold">{{sub_unit_meta.unit_title}}</span>
+      </p>
 
   {% endblock %}
 

--- a/wp-content/themes/fundawande/templates/mixins.twig
+++ b/wp-content/themes/fundawande/templates/mixins.twig
@@ -30,10 +30,17 @@
 {% endmacro %}
 
 {# Add Image Grid Item #}
-{% macro imgGridItem(columns, file, image_src, caption, module_number) %}
+{% macro imgGridItem(columns, file, caption, module_number) %}
     <div class="col-12 {{columns}} text-center pt-3">
-        {% include "lms/content-types/image/image-content.twig" %}
-        <h5 class="text-center mt-3">{{content.caption}}</h5>
+        <div class="img-container">
+            <img src ="{{ file }}">
+            <a class="img-download-icon" href="{{file}}" download>
+                <span class="module-svg-fill-{{module_number}}">
+                    {{source('assets/download_icon.svg')}}
+                </span>
+            </a>
+        </div>   
+        <h5 class="text-center mt-3">{{caption}}</h5>
     </div>
 {% endmacro %}
 

--- a/wp-content/themes/fundawande/templates/mixins.twig
+++ b/wp-content/themes/fundawande/templates/mixins.twig
@@ -29,6 +29,15 @@
     background-image: -webkit-linear-gradient(top, rgba({{ overlay}}, {{ opacity }}), rgba({{ overlay}}, {{ opacity }})), url('{{src}}');
 {% endmacro %}
 
+{# Add Image Grid Item #}
+{% macro imgGridItem(columns, file, image_src, caption, module_number) %}
+    <div class="col-12 {{columns}} text-center pt-3">
+        {% include "lms/content-types/image/image-content.twig" %}
+        <h5 class="text-center mt-3">{{content.caption}}</h5>
+    </div>
+{% endmacro %}
+
+
 {# Add PDF Image #}
 {% macro pdfImage(columns, file, image_src, lang, module_number) %}
     {% import _self as mixins %}


### PR DESCRIPTION
### Release meta:
* Product owner: Vusi
* Contributors: Jason Tame
* Branch: foo/image-grid
* Pull request: 
* Approved by: 
* Change significance:

### Context:
There are already video and PDF grid content types available on the Funda Wande solution. There was a need to also have a simple image grid available. 

### Change(s):
This PR adds the code for the image grid content type. It allows for a single row of between 2 and 4 items to be displayed within the lesson. 

![Image grid](https://i.imgur.com/SoQRTBl.png)

### Testing:
This has been tested using 2, 3 and 4 images on all device sizes

