### PR TITLE
Add audio as an option for additional lesson resources

### DIFF
--- a/wp-content/themes/fundawande/templates/lms/embeds/content/audio-resource.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/content/audio-resource.twig
@@ -1,4 +1,4 @@
-<div class="d-flex flex-wrap align-items-center">
+<div class="d-flex flex-column flex-lg-row flex-lg-wrap align-items-start align-items-lg-center">
 	<div class="d-flex align-items-center">
 		<div class="d-flex align-items-center justify-content-center">
 			{% set media_path = media_url~content.file_name %}
@@ -7,7 +7,7 @@
 
 	</div>
 	<div class="d-flex justify-content-center justify-content-lg-end flex-grow-1 mt-3 mt-lg-0">
-		<a href="{{media_url}}{{content.file_name}}" target="_blank" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2" download>{{attribute(options, lang.prefix~'download_label')}}</a>
+		<a href="{{media_url}}{{content.file_name}}" target="_blank" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-lg-2" download>{{attribute(options, lang.prefix~'download_label')}}</a>
 	</div>
 </div>
 <hr>

--- a/wp-content/themes/fundawande/templates/lms/embeds/content/audio-resource.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/content/audio-resource.twig
@@ -1,0 +1,13 @@
+<div class="d-flex flex-wrap align-items-center">
+	<div class="d-flex align-items-center">
+		<div class="d-flex align-items-center justify-content-center">
+			{% set media_path = media_url~content.file_name %}
+			{{mixin.audioPlayerIcon(media_path, sub_unit_meta.module_number, content.title)}}
+		</div>
+
+	</div>
+	<div class="d-flex justify-content-center justify-content-lg-end flex-grow-1 mt-3 mt-lg-0">
+		<a href="{{media_url}}{{content.file_name}}" target="_blank" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2" download>{{attribute(options, lang.prefix~'download_label')}}</a>
+	</div>
+</div>
+<hr>

--- a/wp-content/themes/fundawande/templates/lms/embeds/content/pdf-resource.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/content/pdf-resource.twig
@@ -1,4 +1,4 @@
-<div class="d-flex flex-wrap align-items-center">
+<div class="d-flex flex-column flex-lg-row flex-lg-wrap align-items-start align-items-lg-center">
     <div class="d-flex align-items-center">
         <span class="pr-3 module-svg-fill-{{sub_unit_meta.module_number}}">
             {{source ('/assets/lms/pdf_file_icon.svg')}}
@@ -9,7 +9,7 @@
         </div>
     </div>
     <div class="d-flex justify-content-center justify-content-lg-end flex-grow-1 mt-3 mt-lg-0">
-        <a href="{{content.file}}" download class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2">{{attribute(options, lang.prefix~'download_label')}}</a>
+        <a href="{{content.file}}" download class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-lg-2">{{attribute(options, lang.prefix~'download_label')}}</a>
         <a href="{{content.file}}" target="_blank" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2">{{attribute(options, lang.prefix~'view_label')}}</a>
     </div>
 </div>

--- a/wp-content/themes/fundawande/templates/lms/embeds/content/video-resource.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/content/video-resource.twig
@@ -1,4 +1,4 @@
-<div class="d-flex flex-wrap align-items-center">
+<div class="d-flex flex-column flex-lg-row flex-lg-wrap align-items-start align-items-lg-center">
     <div class="d-flex align-items-center">
         <span class="pr-3 module-svg-fill-{{sub_unit_meta.module_number}}">
             {{source ('/assets/lms/video_file_icon.svg')}}
@@ -9,7 +9,7 @@
         </div>
     </div>
     <div class="d-flex justify-content-center justify-content-lg-end flex-grow-1 mt-3 mt-lg-0">
-        <a href="{{media_url}}{{content.file_name}}" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2" download>{{attribute(options, lang.prefix~'download_label')}}</a>
+        <a href="{{media_url}}{{content.file_name}}" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-lg-2" download>{{attribute(options, lang.prefix~'download_label')}}</a>
         <a href="{{media_url}}{{content.file_name}}" target="_blank" class="btn module-btn-fill-{{sub_unit_meta.module_number}} mx-2">{{attribute(options, lang.prefix~'view_label')}}</a>
     </div>
 </div>

--- a/wp-content/themes/fundawande/templates/lms/embeds/lesson/downloadable-resources.twig
+++ b/wp-content/themes/fundawande/templates/lms/embeds/lesson/downloadable-resources.twig
@@ -15,6 +15,9 @@
                         {% if content.acf_fc_layout == 'video' %}
                             {% include "lms/embeds/content/video-resource.twig" %}
                         {% endif %}
+                        {% if content.acf_fc_layout == 'audio' %}
+                            {% include "lms/embeds/content/audio-resource.twig" %}
+                        {% endif %}
                     {% endfor %}
                 </div>
             </div>

--- a/wp-content/themes/fundawande/templates/mixins.twig
+++ b/wp-content/themes/fundawande/templates/mixins.twig
@@ -212,16 +212,23 @@
 {% endmacro %}
 
 {# Add toggleable audio player #}
-{% macro audioPlayerIcon(audio_src, module_number) %}
+{% macro audioPlayerIcon(audio_src, module_number, title = "") %}
     {% import _self as mixins %}
 
     <div class="audio_player_container">
         <audio class="audio" preload="true">
             <source src="{{ audio_src }}">
         </audio>
-        <div class="open-toggle">
+        <div class="open-toggle d-flex align-items-center">
             <span class="module-text-{{module_number}}">{{ source('/assets/audio_player/speaker_icon.svg') }}</span>
-            Play Audio
+            {% if title %}
+                <div class="d-flex flex-column pl-3">
+                    <h5>{{title}}</h5>
+                    <h5 class="text-small text-italic">Audio file (click to play)</h5>
+                </div>
+            {% else %}
+                <h5 class="pl-3">Play Audio</h5>
+            {% endif %}
         </div>
         <div class="audio_player module-before-border-{{ module_number }} module-border-{{ module_number }} mt-3">
             <button  class="play__button module-text-{{ module_number }}">►</button>


### PR DESCRIPTION
### Context
The FW team requested the ability to add audio files as additional resources as lessons

### Changes

Audio files can now be added in the same way that PDFs or video resources. They will display a little differently though:

![image](https://user-images.githubusercontent.com/15672948/90412279-361c2680-e0ad-11ea-9500-40aad15b4cdd.png)

If the speaker icon is clicked, a simple audio player is shown:

![image](https://user-images.githubusercontent.com/15672948/90412436-64016b00-e0ad-11ea-8386-37bbc7f7b243.png)

The user could also choose to download by clicking on the button on the right. That will open up the raw mp3 in a new tab, and from there they could right click to download